### PR TITLE
Add call record functionality and update database schema

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -36,7 +36,8 @@ CREATE TABLE IF NOT EXISTS session_progress (
     points_total INTEGER NULL,
     call_unlocked BOOLEAN NULL,
     created_at TIMESTAMPTZ DEFAULT NOW(),
-    updated_at TIMESTAMPTZ DEFAULT NOW()
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    call_record JSONB NULL
 );
 """
 

--- a/src/models/db/db_models.py
+++ b/src/models/db/db_models.py
@@ -33,6 +33,7 @@ class SessionProgress(TypedDict):
     call_unlocked: NotRequired[bool]
     created_at: NotRequired[datetime]
     updated_at: NotRequired[datetime]
+    call_record: NotRequired[List[Dict[str, str]]]
 
 class SessionTransfer(TypedDict):
     """Model storing transfer links when a user resets a session."""

--- a/src/models/goal.py
+++ b/src/models/goal.py
@@ -5,6 +5,7 @@ from langchain_core.messages import BaseMessage
 from pydantic import BaseModel
 from datetime import datetime
 
+
 class Mission(BaseModel):
     """Mission model."""
     id: str
@@ -104,6 +105,11 @@ class ClarifyResponse(BaseModel):
     why: str
     fallbackToGenericData: bool
 
+class CallRecord(BaseModel):
+    """Model to store Call Record"""
+    id: str
+    uid: str
+
 class PersonalisedData(BaseModel):
     """Response model for personalised data"""
     hero: Hero
@@ -116,6 +122,7 @@ class PersonalisedData(BaseModel):
     fallbackToGenericData: bool
     points_total: int
     call_unlocked: bool
+    call_record: List[CallRecord]
 
 class PersonalisedResponse(BaseModel):
     """Response model for personalised data"""

--- a/src/models/mission.py
+++ b/src/models/mission.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
-from .goal import Mission
+from src.models.goal import Mission
 
 
 class MissionStatus(BaseModel):
@@ -43,3 +43,13 @@ class CompleteMissionResponse(BaseModel):
 class UnlockStatusResponse(BaseModel):
     """Response for unlock status check."""
     call_unlocked: bool
+
+class LinkCallRequest(BaseModel):
+    """Request model to link booked call data with session_id"""
+    id: str
+    uid: str
+
+class LinkCallResponse(BaseModel):
+    """Response model to return data after linking booked call data with session_id"""
+    status: bool
+    messages: str

--- a/src/routes/goals.py
+++ b/src/routes/goals.py
@@ -474,7 +474,8 @@ async def get_personalized_content(session_id: str = Depends(get_current_session
                 why=progress.get("why", "") or "",
                 fallbackToGenericData=False,
                 points_total=progress.get("points_total", 0) or 0,
-                call_unlocked=progress.get("call_unlocked", False) or False
+                call_unlocked=progress.get("call_unlocked", False) or False,
+                call_record=progress.get("call_record", []) or []
             )
 
             print("Sending Response from db storage")
@@ -522,6 +523,9 @@ async def get_personalized_content(session_id: str = Depends(get_current_session
                         response_data["points_total"] = 0
                     if "call_unlocked" not in response_data:
                         response_data["call_unlocked"] = False
+                    
+                    if "call_record" not in response_data:
+                        response_data["call_record"] = []
 
                     # Create PersonalisedData object
                     personalised_data = PersonalisedData(**response_data)
@@ -538,7 +542,8 @@ async def get_personalized_content(session_id: str = Depends(get_current_session
                         why="",
                         fallbackToGenericData=True,
                         points_total=0,
-                        call_unlocked=False
+                        call_unlocked=False,
+                        call_record=[]
                     )
                 
                 # For CLARIFIED status, we return structured data, so messages can be empty
@@ -558,6 +563,7 @@ async def get_personalized_content(session_id: str = Depends(get_current_session
                     why="",
                     points_total=0,
                     call_unlocked=False,
+                    call_record=[],
                     fallbackToGenericData=True
                 )
         else:
@@ -574,6 +580,7 @@ async def get_personalized_content(session_id: str = Depends(get_current_session
                 why="",
                 points_total=0,
                 call_unlocked=False,
+                call_record=[],
                 fallbackToGenericData=True
             )
 

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -1,6 +1,5 @@
 """Chat service for the chat endpoint"""
 
-import json
 import traceback
 from typing import List
 from langchain.prompts import ChatPromptTemplate
@@ -50,10 +49,6 @@ class ChatService:
             return response
         except Exception as e:
             print(f"LLM Parse Error: {e}", traceback.format_exc())
-
-
-
-        
 
 
     async def ask(self, *, session_id: str, message: str, page: str, section: str):


### PR DESCRIPTION
- Introduced a new `call_record` field in the `session_progress` table to store call details.
- Added `CallRecord` model to represent individual call records in the system.
- Updated `PersonalisedData` model to include a list of `call_record` entries.
- Implemented new endpoint `/call/link` to handle call bookings and store call records.
- Enhanced session management to support storing and retrieving call records for user sessions.